### PR TITLE
Close file after Upload ran

### DIFF
--- a/spaces.php
+++ b/spaces.php
@@ -281,6 +281,10 @@ class SpacesConnect {
          }
          catch (\Exception $e) {
           $this->HandleAWSException($e);
+         } finally {     
+            if (is_file($pathToFile)) {
+                fclose($file);
+            }
          }
     }
 


### PR DESCRIPTION
I saw here the need to delete the file and because it was already open (fopen) inside the library, exclusion was not allowed.
Now always closing (fclose) the file, this is possible.
This is most often used when you want to delete a temporary file after uploading.