### PR TITLE
Suppress warning in case a blob is uploaded

### DIFF
--- a/spaces.php
+++ b/spaces.php
@@ -259,7 +259,8 @@ class SpacesConnect {
         if($access == "public") {
           $access = "public-read";
         }
-        if(!is_file($pathToFile)){
+        $is_file = strlen($pathToFile) <= PHP_MAXPATHLEN && is_file($pathToFile);
+        if(!$is_file){
           $file = $pathToFile;
         }else{
           $file = fopen($pathToFile, 'r+');
@@ -283,7 +284,7 @@ class SpacesConnect {
          catch (\Exception $e) {
           $this->HandleAWSException($e);
          } finally {     
-            if (is_file($pathToFile)) {
+            if ($is_file) {
                 fclose($file);
             }
          }


### PR DESCRIPTION
In case you use `UploadFile($pathToFile, $access, $save_as, $mime_type)` to upload a blob instead of a file, you get a warning on the call of `is_file($pathToFile)`. This workaround adds a check on the length as blobs are typically bigger than path names. The change is backwards compatible with existing code.

It would be better to add a new method `UploadBlob()` and limit `UploadFile()` to files only. But such a change will break existing code which uses `UploadFile()` to upload blobs.
