### PR TITLE
Warning about forward slash for paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ All available options:
 
 ### Uploading/Downloading Files
 ```php
+// Don't start any path with a forward slash, or it will give "SignatureDoesNotMatch" exception
 $path_to_file = "image.png";
 
 $space->UploadFile($path_to_file, "public");


### PR DESCRIPTION
Just adding a warning based on your response to this issue https://github.com/SociallyDev/Spaces-API/issues/6 , 
I know you probably tried the filter you talked about because I didn't get the exception when using `UploadDirectory()`, but then I got the exception when using `MakePublic()`, so I thought it would be safer for everyone to warn them about that `SignatureDoesNotMatch` exception