### PR TITLE
fclose($file) exception on file upload (GC).

### DIFF
--- a/spaces.php
+++ b/spaces.php
@@ -289,7 +289,7 @@ class SpacesConnect {
          catch (\Exception $e) {
           $this->HandleAWSException($e);
          } finally {
-            if ($is_file) {
+            if (is_resource($file)) {
                 fclose($file);
             }
          }


### PR DESCRIPTION
It happens that fclose($file) triggers an Exception because the resource ($file variable) is already closed.
After investigation, it seems that the $file get closed in the putObject function (l. 274) when the garbage collector cleans the memory.
The change fix this issue.

Here is the related issue on the aws sdk repo: 
https://github.com/aws/aws-sdk-php/issues/929