### PR TITLE
Allows for object parameters be set on text upload

### DIFF
--- a/spaces.php
+++ b/spaces.php
@@ -150,10 +150,10 @@ class Space {
   /*
   Uploads text.
   */
-  function upload($text, $saveAs, $privacy = "private") {
+  function upload($text, $saveAs, $privacy = "private", $params = array()) {
     if($privacy == "public") { $privacy = "public-read"; }
 
-    return SpacesResult($this->s3->upload($this->name, $saveAs, $text, $privacy));
+    return SpacesResult($this->s3->upload($this->name, $saveAs, $text, $privacy, array( 'params' => $params)));
   }
 
 


### PR DESCRIPTION
The default ContentType is 'application/octet-stream' which forces files to be downloaded instead of opened by the browser. 
Setting the ContentType to match the file mime type takes care of it.

//Example
$my_space->upload( 'world', "hello.txt", "public", array('ContentType' => 'text/plain'));
$my_space->upload( $imageBlob, "happy.jpg", "public", array('ContentType' => 'image/jpeg'));

//Other Uses
array('CacheControl' => 'max-age=60', 'ContentEncoding' => 'gzip');

//Source
https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html