### PR TITLE
Allow uploading files from URL

### DIFF
--- a/spaces.php
+++ b/spaces.php
@@ -168,7 +168,7 @@ class Space {
     $content = fopen($filePath, "r");
     $result = $this->s3->upload($this->name, $saveAs, $content, $privacy);
 
-    fclose($content);
+    if(is_resource($content)) { fclose($content); }
     return SpacesResult($result);
   }
 


### PR DESCRIPTION
When uploading files from a URL, and if the server closes the connection directly after sending the file, then the resource will be invalid and an exception will be thrown when trying to close it. The supposed fix is to check if the resource is valid.