### PR TITLE
Feature/upgrade guzzle version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .DS_Store
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": ">=5.4.0",
     "aws/aws-sdk-php": "^3.52",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^6.2.1|^7.0",
     "mtdowling/jmespath.php": "^2.4",
     "psr/http-message": "^1.0"
   },


### PR DESCRIPTION
Recently I found a problem upgrading a project to Symfony 5.2, which has Guzzle 7 as a requirement.

The package https://packagist.org/packages/aws/aws-sdk-php already had Guzzle 6 + 7 as a requirement, so upgrading the version of Guzzle fixed the issue.