### PR TITLE
pin-supported-aws-version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "require": {
     "php": ">=5.4.0",
-    "aws/aws-sdk-php": "^3.52",
+    "aws/aws-sdk-php": "3.52.0",
     "guzzlehttp/guzzle": "^6.3",
     "mtdowling/jmespath.php": "^2.4",
     "psr/http-message": "^1.0"


### PR DESCRIPTION
File upload breaks on new AWS SDK version with error "Error executing "PutObject" on "spacename.https://ams3.digitaloceanspaces.com"; AWS HTTP error: cURL error 1: Protocol "spacename.https" not supported or disabled in libcurl (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)
Pinning the previous supported version fixes the problem.